### PR TITLE
use spotlight to find installers when no argument is given

### DIFF
--- a/osxapp_vers
+++ b/osxapp_vers
@@ -63,9 +63,11 @@ SUPPORTED_OS=$(printf "%s\n" ${SUPPORTED_OS[@]})
 
 if [ $# = 0 ]; then
     # No args have been given
-    # Find any OS X installers in /Applications
-    FILES=$(ls -ld1 /Applications/Install\ *OS\ X\ *.app 2>/dev/null;\
-            ls -ld1 /Applications/Install\ macOS\ *.app 2>/dev/null)
+    # Find any OS X installers known to the Spotlight
+    FILES=$(
+            mdfind "kMDItemFSName == 'Install OS X *.app'" 2>/dev/null;\
+            mdfind "kMDItemFSName == 'Install macOS *.app'" 2>/dev/null;\
+            )
 else
     # Use the program arguments as the input
     FILES=$(printf "%s\n" $@)
@@ -73,7 +75,7 @@ fi
 
 # Error message if there is no installer
 if [ -z "$FILES" ]; then
-    printf "INFO:  There is no \"Install *OS X *.app\" and no \"Install macOS *.app\" in /Applications\n"
+    printf "INFO:  There is no \"Install *OS X *.app\" and no \"Install macOS *.app\" known to Spotlight\n"
 else
     for FILE in $FILES; do
         # print the app folder


### PR DESCRIPTION
Use spotlight to find possible installers, instead of defaulting to `/Applications`.
Makes the script more helpful when you're backing up installers outside of that folder.

If the script changes are acceptable, I will update the README as well.