### PR TITLE
improve handling of BaseSystem mounting

### DIFF
--- a/osxapp_vers
+++ b/osxapp_vers
@@ -119,7 +119,7 @@ else
                 exit
             fi
 
-            if [ "$OSNAME" = "Mojave" -o "$OSNAME" = "High Sierra" ]; then
+            if [[ -e "$APPNAME/Contents/SharedSupport/BaseSystem.dmg" ]]; then
             # Starting with High Sierra ...
                 # Mount the BaseSystem.dmg
                 hdiutil attach "$APPNAME/Contents/SharedSupport/BaseSystem.dmg" \


### PR DESCRIPTION
instead of hardcoding a growing list of OS names, we can just detect if the BaseSystem.dmg is immediately available.

So when the Mojave successor comes along, users just need to set the `NOCHECK` env var to get rid of a warning, instead of the script failing.